### PR TITLE
[audio_comport_device]fix none-type issue for get_data

### DIFF
--- a/pyusb_chain/devices/audio_comport_device.py
+++ b/pyusb_chain/devices/audio_comport_device.py
@@ -80,7 +80,7 @@ class AudioCOMPortDevice(AudioDevice):
 
     def _get_data(self, allInfo=False, isDict=False, portName=None):
         d = super(AudioCOMPortDevice, self)._get_data(allInfo, isDict, portName)
-        if "com" in portName.lower():
+        if portName and "com" in portName.lower():
             if isDict:
                 if portName:
                     d["Port Name"] = portName


### PR DESCRIPTION
Signed-off-by: Harry Qian <huan.qian@nxp.com>

To fix None-Type issue:

> PS C:\repos\pycpld> python .\cpld.py -lb
> Scanning all USB devices...
> Traceback (most recent call last):
>   File "C:\repos\pycpld\cpld.py", line 188, in <module>
>     main()
>   File "C:\Program Files\Python39\lib\site-packages\click\core.py", line 829, in __call__
>     return self.main(*args, **kwargs)
>   File "C:\Program Files\Python39\lib\site-packages\click\core.py", line 782, in main
>     rv = self.invoke(ctx)
>   File "C:\Program Files\Python39\lib\site-packages\click\core.py", line 1066, in invoke
>     return ctx.invoke(self.callback, **ctx.params)
>   File "C:\Program Files\Python39\lib\site-packages\click\core.py", line 610, in invoke
>     return callback(*args, **kwargs)
>   File "C:\repos\pycpld\cpld.py", line 56, in main
>     print_usb_blaster_info(usbTree)
>   File "C:\repos\pycpld\cpld.py", line 177, in print_usb_blaster_info
>     devices = usbTree.filter("Altera")
>   File "C:\Program Files\Python39\lib\site-packages\pyusb_chain\usb_tree_view_tool.py", line 287, in filter
>     dataHash = device.export_data()
>   File "C:\Program Files\Python39\lib\site-packages\pyusb_chain\devices\audio_comport_device.py", line 73, in export_data 
>     data = super(AudioCOMPortDevice, self).export_data(allInfo, jsonFormat)
>   File "C:\Program Files\Python39\lib\site-packages\pyusb_chain\devices\audio_device.py", line 97, in export_data
>     data.append(self._get_data(allInfo=allInfo, isDict=False, portName=self.audioPlaybackName))
>   File "C:\Program Files\Python39\lib\site-packages\pyusb_chain\devices\audio_comport_device.py", line 83, in _get_data   
>     if "com" in portName.lower():
> AttributeError: 'NoneType' object has no attribute 'lower'